### PR TITLE
Redirect if text query param missing

### DIFF
--- a/4-azure-functions-python-vscode/sentiment/__init__.py
+++ b/4-azure-functions-python-vscode/sentiment/__init__.py
@@ -5,6 +5,8 @@ from vaderSentiment.vaderSentiment import SentimentIntensityAnalyzer
 def main(req: func.HttpRequest) -> func.HttpResponse:
     analyzer = SentimentIntensityAnalyzer()
     text = req.params.get("text")
+    if text is None:
+        return func.HttpResponse(status_code=302,headers={"Location":req.url+"?text=I+Love+PyCon"})
     scores = analyzer.polarity_scores(text)
     sentiment = "positive" if scores["compound"] > 0 else "negative"
     return func.HttpResponse(sentiment)

--- a/4-azure-functions-python-vscode/sentiment/__init__.py
+++ b/4-azure-functions-python-vscode/sentiment/__init__.py
@@ -6,7 +6,7 @@ def main(req: func.HttpRequest) -> func.HttpResponse:
     analyzer = SentimentIntensityAnalyzer()
     text = req.params.get("text")
     if text is None:
-        return func.HttpResponse(status_code=302,headers={"Location":req.url+"?text=I+Love+PyCon"})
+        return func.HttpResponse(status_code=302, headers={"Location":req.url+"?text=I+Love+PyCon"})
     scores = analyzer.polarity_scores(text)
     sentiment = "positive" if scores["compound"] > 0 else "negative"
     return func.HttpResponse(sentiment)


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
* Logs present the function default url as below, if user browse to it, they will get an error 500
```
Now listening on: http://0.0.0.0:7071
Application started. Press Ctrl+C to shut down.

Http Functions:

        sentiment: [GET,POST] http://localhost:7071/api/sentiment
```

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[x] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
*  Browsing to the URL without text query param should redirect to URL with text=I+Love+PyCon

## Other Information
<!-- Add any other helpful information that may be needed here. -->