### PR TITLE
minor inverted comma mistake corrected

### DIFF
--- a/4-dapr/README.md
+++ b/4-dapr/README.md
@@ -59,7 +59,7 @@ You can do a quick test by running the following to save and get some state:
 
 ```bash
 # save state
-curl -X POST -H "Content-Type: application/json" -d '[{ "key": "name", "value": "Bruce Wayne"}]' http://localhost:3500/v1.0/state/statestore`
+curl -X POST -H "Content-Type: application/json" -d '[{ "key": "name", "value": "Bruce Wayne"}]' 'http://localhost:3500/v1.0/state/statestore'
 # get state
 curl http://localhost:3500/v1.0/state/statestore/name
 ```

--- a/4-dapr/README.md
+++ b/4-dapr/README.md
@@ -114,7 +114,7 @@ def dapr_get_state(store="statestore", name="name"):
         # Wait for sidecar to be up within 5 seconds.
         d.wait(5)
         res = d.get_state(store_name=store, key=name)
-        print(res.data.decode())s
+        print(res.data.decode())
 ```
 
 You can execute these as follows:


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
* This change only changes 2 charachers
* Only effects Readme.md

## Correction
`main>4-dapr>Readme.md>ln:62`
OLD:
```
curl -X POST -H "Content-Type: application/json" -d '[{ "key": "name", "value": "Bruce Wayne"}]' http://localhost:3500/v1.0/state/statestore`
```
NEW:
```
curl -X POST -H "Content-Type: application/json" -d '[{ "key": "name", "value": "Bruce Wayne"}]'  `http://localhost:3500/v1.0/state/statestore ' 
```



