### PR TITLE
Update prereqs/versions

### DIFF
--- a/01-azure-functions-python-vscode/README.md
+++ b/01-azure-functions-python-vscode/README.md
@@ -12,7 +12,7 @@ You will learn to:
 - An **Azure Subscription** (e.g. [Free](https://aka.ms/azure-free-account) or [Student](https://aka.ms/azure-student-account) account)
 - macOS, Windows, or Linux
 - Python 3.7, 3.8, or 3.9
-- [Azure Functions Core Tools](https://docs.microsoft.com/en-us/azure/azure-functions/functions-run-local#install-the-azure-functions-core-tools). If needed, there are [more ways to install here](https://github.com/Azure/azure-functions-core-tools#installing).
+- [Azure Functions Core Tools](https://docs.microsoft.com/azure/azure-functions/functions-run-local#install-the-azure-functions-core-tools). If needed, there are [more ways to install here](https://github.com/Azure/azure-functions-core-tools#installing).
 - [Visual Studio Code](https://code.visualstudio.com/download) with these extensions installed:
     - [Python](https://marketplace.visualstudio.com/items?itemName=ms-python.python)
     - [Azure Functions](https://marketplace.visualstudio.com/items?itemName=ms-azuretools.vscode-azurefunctions)

--- a/01-azure-functions-python-vscode/README.md
+++ b/01-azure-functions-python-vscode/README.md
@@ -12,6 +12,7 @@ You will learn to:
 - An **Azure Subscription** (e.g. [Free](https://aka.ms/azure-free-account) or [Student](https://aka.ms/azure-student-account) account)
 - macOS, Windows, or Linux
 - Python 3.7, 3.8, or 3.9
+- [Azure Functions Core Tools](https://docs.microsoft.com/en-us/azure/azure-functions/functions-run-local#install-the-azure-functions-core-tools). If needed, there are [more ways to install here](https://github.com/Azure/azure-functions-core-tools#installing).
 - [Visual Studio Code](https://code.visualstudio.com/download) with these extensions installed:
     - [Python](https://marketplace.visualstudio.com/items?itemName=ms-python.python)
     - [Azure Functions](https://marketplace.visualstudio.com/items?itemName=ms-azuretools.vscode-azurefunctions)
@@ -35,7 +36,7 @@ You will build an HTTP API using an Azure Function. An Azure Functions app can c
     | Prompt | Value | Description |
     | --- | --- | --- |
     | Language for your project | **Python** | |
-    | Python interpreter | Select one | Azure Functions requires Python 3.6, 3.7, 3.8 |
+    | Python interpreter | Select one | Azure Functions requires Python 3.7, 3.8, 3.9 |
     | Template for your first function | **HTTP trigger** | |
     | Function name | **sentiment** | |
     | Authorization level | **anonymous** | Allow function to be accessed anonymously |
@@ -80,7 +81,7 @@ VS Code reopens in the function app. Here are some important files and folders t
 
 1. If you don't have the Azure Functions Core Tools installed, VS Code will prompt you to install it. Select **Install**.
 
-    > If the installation fails, follow [these instructions](https://github.com/Azure/azure-functions-core-tools#installing) to install it. Note: Azure Functions Core Tools Version 3 is compatible with Python 3.8, if you are using 3.7 or 3.6 use the v2 command line to install.
+    > If the installation fails, follow [these instructions](https://github.com/Azure/azure-functions-core-tools#installing) to install it.
 
 1. Once the function app has started, open your web browser and enter the following in the address bar to run your function:
 


### PR DESCRIPTION
## Purpose
This PR updates the sentiment analyzer lab prerequisites and version numbers.
For the prereqs, it explicitly mentions Azure Functions Core Tools, which is similarly mentioned here: https://docs.microsoft.com/en-us/azure/azure-functions/create-first-function-vs-code-python#configure-your-environment
I know that later on in the tutorial it describes how to install Core Tools, but I didn't read step 2 after getting stuck on step 1, so I spent a long time trying to figure out what "Core Tools" was and whether it was an extension and why I didn't have it yet. I would have had an easier time if it was explicitly called out as a different thing at the beginning.

Another approach is just to link to https://docs.microsoft.com/en-us/azure/azure-functions/create-first-function-vs-code-python#configure-your-environment instead of repeating the prerequisties for this lab, that way we don't need to keep them in sync.

This guide suggests installing Core Tools 3.x, but 4.x is the current version, so I assume that's preferred. I did get a warning about proxies.json: "Warning: Proxies are not supported in Azure Functions v4. Instead of 'proxies.json', try Azure API Management: https://aka.ms/AAfiueq" so maybe that has to be updated before it can officially use v4? 

I also updated the version numbers in the later table to match the prerequisites (3.7-3.9). However, I do see that 3.6 is a supported language for functions 2.x/3.x, so I don't know if we want to mention that as a possibility or not.

## Does this introduce a breaking change?
```
[ ] Yes
[X] No
```

## Pull Request Type
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[X] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
Preview the MD
